### PR TITLE
Fix CI issue for python 3.7

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,11 +7,15 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
+        runs-on: [ubuntu-latest]
+        include:
+          - python-version: '3.7'
+            runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub workflow's ubuntu-latest now points to 24.04, where Python 3.7 is not available any more.
To fix it, I changed the CI config to let Python 3.7 use ubuntu-22.04. Other versions (3.8, 3.9. 3.10) stay the same.

It has been a few years since we published pytest-inline. I'm planning to do the following upgrades to CI / build config recently, let me know if there is any objections:
1. Add CI tests for newer Python versions (3.11 -- 3.14)
2. Upgrade the build and test toolchain to use `uv`, which should replace `conda` and `tox`
3. We should consider dropping support for older Python versions (3.7, 3.8, 3.9, which are all end of life by now) at some point